### PR TITLE
Fixed yamllint issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 language: php
 
 php:
@@ -33,4 +34,4 @@ script:
   - phpunit --coverage-clover build/logs/clover.xml
 
 after_script:
- - php vendor/bin/coveralls -v
+  - php vendor/bin/coveralls -v


### PR DESCRIPTION
When testing a project, i found the following yamllint errors in my vendor folder
.travis.yml
  1:1       warning  missing document start "---"  (document-start)
  36:2      error    wrong indentation: expected 2 but found 1  (indentation)