### PR TITLE
Add PHP CS Fixer to the project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
 
 script:
   - mkdir -p build/logs
+  - ./bin/php-cs-fixer fix --config=.php_cs.dist --diff --verbose --show-progress=estimating --dry-run
   - ./bin/phpunit --coverage-clover build/logs/clover.xml
 
 after_script:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.4"
+        "phpunit/phpunit": "^7.4",
+        "friendsofphp/php-cs-fixer": "^2.15"
     },
     "suggest": {
         "scheb/tombstone-analyzer": "Analysis tool for tombstone logs"


### PR DESCRIPTION
Adds PHP CS Fixer to the project as a dev dependency, and run it as part of the travis build.