### PR TITLE
Fix undefined index notices

### DIFF
--- a/src/logger/Graveyard/VampireFactory.php
+++ b/src/logger/Graveyard/VampireFactory.php
@@ -76,8 +76,8 @@ class VampireFactory
         $frames = [];
         foreach ($trace as $frame) {
             $frames[] = new StackTraceFrame(
-                $this->rootPath->createFilePath($frame['file']),
-                $frame['line'],
+                $this->rootPath->createFilePath($frame['file'] ?? '/'),
+                $frame['line'] ?? 0,
                 self::getMethodFromFrame($frame)
             );
         }

--- a/tests/Fixture.php
+++ b/tests/Fixture.php
@@ -13,7 +13,7 @@ use Scheb\Tombstone\Core\Model\Vampire;
 class Fixture
 {
     public const ROOT_DIR = '/path/to';
-    public const NUMBER_OF_FRAMES = 4;
+    public const NUMBER_OF_FRAMES = 5;
 
     public static function getVampire(string ...$arguments): Vampire
     {
@@ -55,6 +55,11 @@ class Fixture
                 'class' => 'ClassName',
                 'type' => '->',
                 'function' => 'invokerInvokerMethodName',
+            ],
+            [
+                'function' => '__destruct',
+                'class' => 'ClassName',
+                'type' => '->',
             ],
         ];
     }

--- a/tests/Logger/Graveyard/VampireFactoryTest.php
+++ b/tests/Logger/Graveyard/VampireFactoryTest.php
@@ -44,6 +44,11 @@ class VampireFactoryTest extends TestCase
         $this->assertEquals(44, $frame->getLine());
         $this->assertEquals('ClassName->invokerInvokerMethodName', $frame->getMethod());
 
+        $frame = $stackTrace[4];
+        $this->assertSame('/', $frame->getFile()->getAbsolutePath());
+        $this->assertSame(0, $frame->getLine());
+        $this->assertSame('ClassName->__destruct', $frame->getMethod());
+
         $invocationDate = strtotime($vampire->getInvocationDate());
         $this->assertEquals(time(), $invocationDate);
         $this->assertEqualsWithDelta(time(), $invocationDate, 5);


### PR DESCRIPTION
If PHP internally calls a method that has a `tombstone()` call inside, the backtrace does not have the `file` and `line` keys (in the "previous" entry) which the vampire factory expects so I got a bunch of `Undefined index: file` exceptions on Sentry. This PR fixes that by setting a dummy value for those keys in that case.