### PR TITLE
Implement Redis Logger and Analizer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM php:7.1-cli-alpine3.10
+
+RUN apk add --no-cache --update composer
+
+RUN curl -L -o /tmp/redis.tar.gz https://github.com/phpredis/phpredis/archive/5.3.2.tar.gz \
+    && tar xfz /tmp/redis.tar.gz \
+    && rm -r /tmp/redis.tar.gz \
+    && mv phpredis-5.3.2 /usr/src/php/ext/redis \
+    && docker-php-ext-install redis
+
+WORKDIR /library
+
+COPY ./composer.* ./
+RUN composer install -n --no-autoloader --no-scripts --no-progress --no-suggest
+
+COPY . .
+RUN composer dump-autoload -o -n
+
+ENTRYPOINT tail -f /dev/null

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+.DEFAULT_GOAL := up
+
+.PHONY: up
+up:
+	$(MAKE) down
+	docker-compose up -d
+
+.PHONY: down
+down:
+	docker-compose down --remove-orphans
+
+.PHONY: build
+build:
+	docker-compose build
+	$(MAKE) up
+
+.PHONY: shell
+shell:
+	docker exec -it tombstone-library sh
+
+.PHONY: test
+test:
+	docker exec -it tombstone-library vendor/bin/phpunit tests/${filter}
+
+.PHONY: logs
+logs:
+	@docker-compose logs -f --tail=100
+
+.PHONY: setup
+setup:
+	$(MAKE) down
+	rm -fr ./vendor
+	$(MAKE) up
+	docker exec -it tombstone-library composer install

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "php": ">=7.1.3",
         "ext-json": "*",
         "ext-dom": "*",
+        "ext-redis": "5.3.2",
         "nikic/php-parser": "^4.0",
         "phpunit/php-text-template": "^1.2.1|^2.0",
         "psr/log": "^1.0",
@@ -28,7 +29,8 @@
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/css-selector": "^4.4|^5.0",
         "symfony/dom-crawler": "^4.4|^5.0",
-        "vimeo/psalm": "^3.12|^4.0"
+        "vimeo/psalm": "^3.12|^4.0",
+        "symfony/var-dumper": "^4.4"
     },
     "autoload": {
         "psr-4": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.3'
+services:
+  tombstone-library:
+    container_name: tombstone-library
+    build: .
+    volumes:
+      - ./:/library
+
+  tombstone-redis-test:
+    container_name: tombstone-redis-test
+    image: redis:6-alpine

--- a/src/analyzer/Cli/AnalyzeCommand.php
+++ b/src/analyzer/Cli/AnalyzeCommand.php
@@ -8,6 +8,7 @@ use Scheb\Tombstone\Analyzer\Config\Configuration;
 use Scheb\Tombstone\Analyzer\Config\ConfigurationLoader;
 use Scheb\Tombstone\Analyzer\Config\YamlConfigProvider;
 use Scheb\Tombstone\Analyzer\Log\AnalyzerLogProvider;
+use Scheb\Tombstone\Analyzer\Log\AnalyzerRedisProvider;
 use Scheb\Tombstone\Analyzer\Log\LogCollector;
 use Scheb\Tombstone\Analyzer\Matching\MethodNameStrategy;
 use Scheb\Tombstone\Analyzer\Matching\PositionStrategy;
@@ -103,7 +104,16 @@ class AnalyzeCommand extends AbstractCommand
     private function createLogCollector(array $config, VampireIndex $vampireIndex): LogCollector
     {
         $logProviders = [];
-        if (isset($config['logs']['directory'])) {
+
+        if (isset($config['driver']['type'])) {
+            switch ($config['driver']['type']) {
+                case 'redis':
+                    $logProviders[] = AnalyzerRedisProvider::create($config, $this->output);
+                    break;
+                default:
+                    throw new \Exception("Unknown driver '" . $config['driver']['type'] . "'");
+            }
+        } elseif (isset($config['logs']['directory'])) {
             $logProviders[] = AnalyzerLogProvider::create($config, $this->output);
         }
 

--- a/src/analyzer/Log/AnalyzerRedisProvider.php
+++ b/src/analyzer/Log/AnalyzerRedisProvider.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\Tombstone\Analyzer\Log;
+
+use Redis;
+use Scheb\Tombstone\Analyzer\Cli\ConsoleOutputInterface;
+use Scheb\Tombstone\Core\Format\AnalyzerLogFormat;
+use Scheb\Tombstone\Core\Model\RootPath;
+
+class AnalyzerRedisProvider implements LogProviderInterface
+{
+    /**
+     * @var RootPath
+     */
+    private $rootDir;
+
+    /**
+     * @var Redis
+     */
+    private $redis;
+
+    /**
+     * @var ConsoleOutputInterface
+     */
+    private $output;
+
+    public function __construct(RootPath $rootDir, Redis $redis, ConsoleOutputInterface $output)
+    {
+        $this->rootDir = $rootDir;
+        $this->redis = $redis;
+        $this->output = $output;
+    }
+
+    public static function create(array $config, ConsoleOutputInterface $consoleOutput): LogProviderInterface
+    {
+        $rootDir = new RootPath($config['source_code']['root_directory']);
+
+        $redis = new Redis();
+        if (isset($config['driver']['password'])) {
+            $redis->auth($config['driver']['password']);
+        }
+
+        $redis->connect(
+            $config['driver']['host'] ?: '',
+            $config['driver']['port'] ?: null,
+            $config['driver']['timeout'] ?: null,
+            $config['driver']['reserved'] ?: null,
+            $config['driver']['retryInterval'] ?: null,
+            $config['driver']['readTimeout'] ?: null
+        );
+
+        return new self(
+            $rootDir,
+            $redis,
+            $consoleOutput
+        );
+    }
+
+    public function getVampires(): iterable
+    {
+        $files = $this->redis->keys('*.tombstone');
+
+        $this->output->writeln('Read analyzer log data ...');
+        $progress = $this->output->createProgressBar(\count($files));
+
+        foreach ($files as $file) {
+            // This is done to reset keys
+            foreach ($this->redis->xRead([$file => '0-0']) as $rows) {
+                foreach ($rows as $timestamp => $line) {
+                    yield AnalyzerLogFormat::logToVampire($line, $this->rootDir);
+                }
+            }
+            $progress->advance();
+        }
+        $this->output->writeln();
+    }
+}

--- a/src/analyzer/Log/AnalyzerRedisProvider.php
+++ b/src/analyzer/Log/AnalyzerRedisProvider.php
@@ -43,12 +43,12 @@ class AnalyzerRedisProvider implements LogProviderInterface
         }
 
         $redis->connect(
-            $config['driver']['host'] ?: '',
-            $config['driver']['port'] ?: 6379,
-            $config['driver']['timeout'] ?: 0.0,
-            $config['driver']['reserved'] ?: null,
-            $config['driver']['retryInterval'] ?: 0,
-            $config['driver']['readTimeout'] ?: 0.0
+            isset($config['driver']['host']) ? $config['driver']['host'] : '',
+            isset($config['driver']['port']) ? $config['driver']['port'] : 6379,
+            isset($config['driver']['timeout']) ? $config['driver']['timeout'] : 0.0,
+            isset($config['driver']['reserved']) ? $config['driver']['reserved'] : null,
+            isset($config['driver']['retryInterval']) ? $config['driver']['retryInterval'] : 0,
+            isset($config['driver']['readTimeout']) ? $config['driver']['readTimeout'] : 0.0
         );
 
         return new self(
@@ -69,7 +69,7 @@ class AnalyzerRedisProvider implements LogProviderInterface
             // This is done to reset keys
             foreach ($this->redis->xRead([$file => '0-0']) as $rows) {
                 foreach ($rows as $timestamp => $line) {
-                    yield AnalyzerLogFormat::logToVampire($line, $this->rootDir);
+                    yield AnalyzerLogFormat::logToVampire($line['data'], $this->rootDir);
                 }
             }
             $progress->advance();

--- a/src/analyzer/Log/AnalyzerRedisProvider.php
+++ b/src/analyzer/Log/AnalyzerRedisProvider.php
@@ -44,11 +44,11 @@ class AnalyzerRedisProvider implements LogProviderInterface
 
         $redis->connect(
             $config['driver']['host'] ?: '',
-            $config['driver']['port'] ?: null,
-            $config['driver']['timeout'] ?: null,
+            $config['driver']['port'] ?: 6379,
+            $config['driver']['timeout'] ?: 0.0,
             $config['driver']['reserved'] ?: null,
-            $config['driver']['retryInterval'] ?: null,
-            $config['driver']['readTimeout'] ?: null
+            $config['driver']['retryInterval'] ?: 0,
+            $config['driver']['readTimeout'] ?: 0.0
         );
 
         return new self(

--- a/src/logger/Handler/AnalyzerRedisHandler.php
+++ b/src/logger/Handler/AnalyzerRedisHandler.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\Tombstone\Logger\Handler;
+
+use Redis;
+use Scheb\Tombstone\Core\Model\Vampire;
+use Scheb\Tombstone\Logger\Formatter\AnalyzerLogFormatter;
+use Scheb\Tombstone\Logger\Formatter\FormatterInterface;
+
+class AnalyzerRedisHandler extends AbstractHandler
+{
+    /**
+     * @var Redis
+     */
+    private $client;
+    /**
+     * @var int
+     */
+    private $sizeLimit;
+
+    public function __construct(Redis $client, int $sizeLimit = 1000)
+    {
+        $this->client = $client;
+        $this->sizeLimit = $sizeLimit;
+    }
+
+    public function log(Vampire $vampire): void
+    {
+        $this->client->xAdd(
+            $this->getLogKey($vampire),
+            '*',
+            ['data' => $this->getFormatter()->format($vampire)],
+            $this->sizeLimit,
+            true
+        );
+    }
+
+    private function getLogKey(Vampire $vampire): string
+    {
+        $date = date('Ymd');
+        $hash = $vampire->getTombstone()->getHash();
+
+        return sprintf('%s-%s.tombstone', $hash, $date);
+    }
+
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new AnalyzerLogFormatter();
+    }
+}

--- a/tests/Logger/Handler/AnalyzerRedisHandlerTest.php
+++ b/tests/Logger/Handler/AnalyzerRedisHandlerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\Tombstone\Tests\Logger\Handler;
+
+use Redis;
+use Scheb\Tombstone\Logger\Handler\AnalyzerRedisHandler;
+use Scheb\Tombstone\Tests\Core\Format\AnalyzerLogFormatTest;
+use Scheb\Tombstone\Tests\Fixture;
+use Scheb\Tombstone\Tests\TestCase;
+
+class AnalyzerRedisHandlerTest extends TestCase
+{
+    /**
+     * @var Redis
+     */
+    private static $redis;
+
+    public static function setUpBeforeClass()
+    {
+        self::$redis = new Redis();
+        self::$redis->connect('tombstone-redis-test');
+    }
+
+    protected function setUp(): void
+    {
+        $this->clearLogFiles();
+    }
+
+    public function tearDown(): void
+    {
+        $this->clearLogFiles();
+    }
+
+    private function clearLogFiles(): void
+    {
+        $logFiles = self::$redis->keys('*');
+
+        self::$redis->del($logFiles[0], ...array_splice($logFiles, 1));
+    }
+
+    private function getLogFiles(): array
+    {
+        return self::$redis->keys('*');
+    }
+
+    private function readLogFiles(array $logFiles): string
+    {
+        $logFileContent = "";
+        foreach (self::$redis->xRead([$logFiles[0] => '0-0']) as $rows) {
+            foreach ($rows as $timestamp => $row) {
+                $logFileContent .= $row['data'];
+            }
+        }
+
+        return $logFileContent;
+    }
+
+    /**
+     * @test
+     */
+    public function log_differentTombstones_twoLogFilesWritten(): void
+    {
+        $handler = new AnalyzerRedisHandler(self::$redis);
+        $handler->log(Fixture::getVampire('2015-01-01'));
+        $handler->log(Fixture::getVampire('2014-01-01'));
+
+        $logFiles = $this->getLogFiles();
+        $this->assertCount(2, $logFiles);
+    }
+
+    /**
+     * @test
+     */
+    public function log_sizeLimitSet_stopWhenLimitExceeded(): void
+    {
+        $handler = new AnalyzerRedisHandler(self::$redis, 500);
+        for ($i = 0; $i < 1000; $i++) {
+            $handler->log(Fixture::getVampire('2015-01-01'));
+        }
+
+        $logFiles = $this->getLogFiles();
+        $lineCount = substr_count($this->readLogFiles($logFiles), "\n");
+
+        $this->assertCount(1, $logFiles);
+        $this->assertLessThan(500 + 500, $lineCount);
+    }
+
+    /**
+     * @test
+     */
+    public function log_logWritten_isAnalyzerLogFormat(): void
+    {
+        $handler = new AnalyzerRedisHandler(self::$redis);
+        $handler->log(Fixture::getVampire(...AnalyzerLogFormatTest::TOMBSTONE_ARGUMENTS));
+
+        $logFiles = $this->getLogFiles();
+        $this->assertCount(1, $logFiles);
+
+        $logFileContent = $this->readLogFiles($logFiles);
+        $this->assertEquals(AnalyzerLogFormatTest::LOG_RECORD.PHP_EOL, $logFileContent);
+    }
+}


### PR DESCRIPTION
Hi, I've spend half a day or so working on this and I wanted to run this by you before I spend excessive amount of time finalising everything.

First, a little bit of background.

The built in logger and analyser is not good enough for my use case, the application I want to test is dockerized and there is no easy way to persist files between container restarts.

I've considered few external storage options (s3, sql, memcache, redis) and decided that Redis would work best for this:
* Redis instance can be setup to persist cache. There is a chance that between server restarts recently pushed data is lost but from what I understand loosing a few tombstone logs doesn't have any significant overall effect.
* Redis 6.0 introduced stream functionality
* Redis is an in memory cache which should ensure performance is not greatly affected.

Other changes:
* Added docker to simplify development and ensure environment for all developers is the same. This may need some adjustment I'm not sure how this can be transferred to Travis
* For now the Redis Logger tests just test against test Redis instance, setup in docker-compose.yml, this will not work in Travis, let me know if you have any suggestion on how to address this
* In our workplace we use Makefile to setup some commonly used commands, usually docker related commands, not sure if you are OK with these

Let me know if there is anything out of place that you would like me to chance.
