### PR TITLE
Removing version on bootstrap link header

### DIFF
--- a/src/analyzer/Report/Html/Template/dashboard.html.dist
+++ b/src/analyzer/Report/Html/Template/dashboard.html.dist
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>Tombstones Dashboard</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="{{path_to_root}}_css/bootstrap.min.css?v=4.1.3" rel="stylesheet">
+    <link href="{{path_to_root}}_css/bootstrap.min.css" rel="stylesheet">
     <link href="{{path_to_root}}_css/style.css" rel="stylesheet">
 </head>
 <body>

--- a/src/analyzer/Report/Html/Template/directory.html.dist
+++ b/src/analyzer/Report/Html/Template/directory.html.dist
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>Tombstones in {{item_local_path}}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="{{path_to_root}}_css/bootstrap.min.css?v=4.1.3" rel="stylesheet">
+    <link href="{{path_to_root}}_css/bootstrap.min.css" rel="stylesheet">
     <link href="{{path_to_root}}_css/style.css" rel="stylesheet">
 </head>
 <body>

--- a/src/analyzer/Report/Html/Template/file.html.dist
+++ b/src/analyzer/Report/Html/Template/file.html.dist
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>Tombstones in {{item_local_path}}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="{{path_to_root}}_css/bootstrap.min.css?v=4.1.3" rel="stylesheet">
+    <link href="{{path_to_root}}_css/bootstrap.min.css" rel="stylesheet">
     <link href="{{path_to_root}}_css/style.css" rel="stylesheet">
 </head>
 <body>


### PR DESCRIPTION
**Description**
This removes the versioning on bootstrap to avoid breaking the styling of the HTML report.

Related to issue #22 