### PR TITLE
Add more psr/log versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ext-dom": "*",
         "nikic/php-parser": "^4.0",
         "phpunit/php-text-template": "^1.2.1|^2.0",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0|^2.0|^3.0",
         "symfony/finder": "^4.1|^5.0",
         "symfony/config": "^3.4|^4.0|^5.0",
         "symfony/console": "^3.4|^4.0|^5.0",

--- a/src/logger/composer.json
+++ b/src/logger/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=7.1.3",
         "ext-json": "*",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0|^2.0|^3.0",
         "scheb/tombstone-core": "self.version"
     },
     "suggest": {


### PR DESCRIPTION
Hi, I was trying to install `scheb/tombstone` in my project but I had some dependency issues:

```console
$ composer require scheb/tombstone-logger -W
Using version ^1.5 for scheb/tombstone-logger
./composer.json has been updated
Running composer update scheb/tombstone-logger --with-all-dependencies
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - scheb/tombstone-logger[v1.5.0, ..., v1.5.1] require psr/log ^1.0 -> found psr/log[1.0.0, ..., 1.1.4] but these were not loaded, likely because it conflicts with another require.
    - Root composer.json requires scheb/tombstone-logger ^1.5 -> satisfiable by scheb/tombstone-logger[v1.5.0, v1.5.1].

You can also try re-running composer require with an explicit version constraint, e.g. "composer require scheb/tombstone-logger:*" to figure out if any version is installable, or "composer require scheb/tombstone-logger:^2.1" if you know which you need.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```

After further investigation I found that -in my project- `monolog` was incompatible with `psr/log` v1:

```console
$ composer why psr/log
doctrine/migrations   3.4.2  requires psr/log (^1.1.3 || ^2 || ^3) 
monolog/monolog       3.2.0  requires psr/log (^2.0 || ^3.0) ⬅️ HERE!      
symfony/cache         v6.1.3 requires psr/log (^1.1|^2|^3)         
symfony/error-handler v6.1.3 requires psr/log (^1|^2|^3)           
symfony/http-client   v6.1.4 requires psr/log (^1|^2|^3)           
symfony/http-kernel   v6.1.4 requires psr/log (^1|^2|^3)           
symfony/mailer        v6.1.4 requires psr/log (^1|^2|^3)           
symfony/notifier      v5.4.0 requires psr/log (^1|^2|^3)   
```

So, in order to improve compatibility I modified `composer.json` to accept `psr/log` v2 and v3.