### PR TITLE
Checking correct method exists

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,7 +26,7 @@ abstract class TestCase extends PHPUnitTestCase
      */
     public static function assertDirectoryDoesNotExist(string $directory, string $message = ''): void
     {
-        if (method_exists(PHPUnitTestCase::class, 'expectExceptionMessageMatches')) {
+        if (method_exists(PHPUnitTestCase::class, 'assertDirectoryDoesNotExist')) {
             parent::assertDirectoryDoesNotExist($directory, $message);
         } else {
             static::assertFalse(is_dir($directory), $message);


### PR DESCRIPTION
**Description**
updating assertDirectoryDoesNotExist to test for the correct method when using the old version of PHPUnit

There is an issue with the test `ensureDirectoryCreated_directoryAlreadyCreated_doNothing` it fails when using PHP 7.2, The base class `TestCase` which extends PHPUnit to help with backward compatibility is incorrect. The method `assertDirectoryDoesNotExist` is checking for `expectExceptionMessageMatches` not it's self.

**Suggestion**
As this package supports PHP 7.1 and great maybe all versions should be tested in the CI?

closes #26 
