### PR TITLE
Adding newer packages versions for PHP 8+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,13 @@
         "php": ">=7.1.3",
         "ext-json": "*",
         "ext-dom": "*",
-        "nikic/php-parser": "^4.0",
-        "phpunit/php-text-template": "^1.2.1|^2.0",
+        "nikic/php-parser": "^4.0|^5.0",
+        "phpunit/php-text-template": "^1.2.1|^2.0|^3.0",
         "psr/log": "^1.0|^2.0|^3.0",
-        "symfony/finder": "^4.1|^5.0",
-        "symfony/config": "^3.4|^4.0|^5.0",
-        "symfony/console": "^3.4|^4.0|^5.0",
-        "symfony/yaml": "^3.4|^4.0|^5.0"
+        "symfony/finder": "^4.1|^5.0|^6.0",
+        "symfony/config": "^3.4|^4.0|^5.0|^6.0",
+        "symfony/console": "^3.4|^4.0|^5.0|^6.0",
+        "symfony/yaml": "^3.4|^4.0|^5.0|^6.0"
     },
     "require-dev": {
         "escapestudios/symfony2-coding-standard": "^3.9",

--- a/psalm.xml
+++ b/psalm.xml
@@ -7,6 +7,7 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
 	findUnusedBaselineEntry="true"
 	findUnusedCode="false"
+	phpVersion="8.3"
 >
     <projectFiles>
         <directory name="src/" />

--- a/src/analyzer/Cli/Application.php
+++ b/src/analyzer/Cli/Application.php
@@ -13,27 +13,15 @@ class Application extends AbstractApplication
     public function __construct()
     {
         parent::__construct('cli', '');
+        parent::setDefaultCommand('analyze');
     }
 
-    protected function getCommandName(InputInterface $input)
-    {
-        return 'analyze';
-    }
-
-    protected function getDefaultCommands()
+    protected function getDefaultCommands(): array
     {
         $defaultCommands = AbstractApplication::getDefaultCommands();
         $defaultCommands[] = new AnalyzeCommand();
 
         return $defaultCommands;
-    }
-
-    public function getDefinition()
-    {
-        $inputDefinition = AbstractApplication::getDefinition();
-        $inputDefinition->setArguments();
-
-        return $inputDefinition;
     }
 
     public function doRun(InputInterface $input, OutputInterface $output): int

--- a/src/analyzer/Config/YamlConfigProvider.php
+++ b/src/analyzer/Config/YamlConfigProvider.php
@@ -8,6 +8,11 @@ use Scheb\Tombstone\Core\Model\RootPath;
 use Scheb\Tombstone\Core\PathNormalizer;
 use Symfony\Component\Yaml\Yaml;
 
+/**
+ * @psalm-type SourceConfig array{root_directory: string}
+ * @psalm-type LogConfig array{directory: string, custom: array{file: string}}
+ * @psalm-type ReportConfig array{php: string, checkstyle: string, html: string}
+ */
 class YamlConfigProvider implements ConfigProviderInterface
 {
     /**
@@ -30,6 +35,9 @@ class YamlConfigProvider implements ConfigProviderInterface
 
     public function readConfiguration(): array
     {
+        /**
+         * @var array{source_code: SourceConfig, logs: LogConfig, report: ReportConfig}  $config
+         */
         $config = Yaml::parseFile($this->configFile);
 
         if (isset($config['source_code']['root_directory'])) {

--- a/src/analyzer/composer.json
+++ b/src/analyzer/composer.json
@@ -13,13 +13,13 @@
     "require": {
         "php": ">=7.1.3",
         "ext-dom": "*",
-        "nikic/php-parser": "^4.0",
-        "phpunit/php-text-template": "^1.2.1|^2.0",
+        "nikic/php-parser": "^4.0|^5.0",
+        "phpunit/php-text-template": "^1.2.1|^2.0|^3.0",
         "scheb/tombstone-core": "self.version",
-        "symfony/finder": "^4.1|^5.0",
-        "symfony/config": "^3.4|^4.0|^5.0",
-        "symfony/console": "^3.4|^4.0|^5.0",
-        "symfony/yaml": "^3.4|^4.0|^5.0"
+        "symfony/finder": "^4.1|^5.0|^6.0",
+        "symfony/config": "^3.4|^4.0|^5.0|^6.0",
+        "symfony/console": "^3.4|^4.0|^5.0|^6.0",
+        "symfony/yaml": "^3.4|^4.0|^5.0|^6.0"
     },
     "bin": [
         "tombstone-analyzer"


### PR DESCRIPTION
**Description**
When adding the package on newer versions of PHP 8+ while PHPUnit is present the user gets an older version, this is because of conflicts with `phpunit/php-text-template` so Composer will serve a version where this conflict doesn't exist.

It's not a bug, but it would be nice if users could get the latest version. 

Changes in the PR allow for projects with PHPUnit already installed to get the newer versions.

closes #30 
