### PR TITLE
Add compatibility with symfony/finder 3.4 and Symfony 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "nikic/php-parser": "^4.0|^5.0",
         "phpunit/php-text-template": "^1.2.1|^2.0|^3.0",
         "psr/log": "^1.0|^2.0|^3.0",
-        "symfony/finder": "^4.1|^5.0|^6.0",
+        "symfony/finder": "^3.4|^4.1|^5.0|^6.0",
         "symfony/config": "^3.4|^4.0|^5.0|^6.0",
         "symfony/console": "^3.4|^4.0|^5.0|^6.0",
         "symfony/yaml": "^3.4|^4.0|^5.0|^6.0"

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
         "nikic/php-parser": "^4.0|^5.0",
         "phpunit/php-text-template": "^1.2.1|^2.0|^3.0",
         "psr/log": "^1.0|^2.0|^3.0",
-        "symfony/finder": "^3.4|^4.1|^5.0|^6.0",
-        "symfony/config": "^3.4|^4.0|^5.0|^6.0",
-        "symfony/console": "^3.4|^4.0|^5.0|^6.0",
-        "symfony/yaml": "^3.4|^4.0|^5.0|^6.0"
+        "symfony/finder": "^3.4|^4.1|^5.0|^6.0|^7.0",
+        "symfony/config": "^3.4|^4.0|^5.0|^6.0|^7.0",
+        "symfony/console": "^3.4|^4.0|^5.0|^6.0|^7.0",
+        "symfony/yaml": "^3.4|^4.0|^5.0|^6.0|^7.0"
     },
     "require-dev": {
         "escapestudios/symfony2-coding-standard": "^3.9",

--- a/src/analyzer/Config/Configuration.php
+++ b/src/analyzer/Config/Configuration.php
@@ -11,7 +11,7 @@ class Configuration implements ConfigurationInterface
 {
     public const CONFIG_ROOT = '';
 
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder(self::CONFIG_ROOT);
         if (method_exists($treeBuilder, 'getRootNode')) {

--- a/src/analyzer/composer.json
+++ b/src/analyzer/composer.json
@@ -16,10 +16,10 @@
         "nikic/php-parser": "^4.0|^5.0",
         "phpunit/php-text-template": "^1.2.1|^2.0|^3.0",
         "scheb/tombstone-core": "self.version",
-        "symfony/finder": "^3.4|^4.1|^5.0|^6.0",
-        "symfony/config": "^3.4|^4.0|^5.0|^6.0",
-        "symfony/console": "^3.4|^4.0|^5.0|^6.0",
-        "symfony/yaml": "^3.4|^4.0|^5.0|^6.0"
+        "symfony/finder": "^3.4|^4.1|^5.0|^6.0|^7.0",
+        "symfony/config": "^3.4|^4.0|^5.0|^6.0|^7.0",
+        "symfony/console": "^3.4|^4.0|^5.0|^6.0|^7.0",
+        "symfony/yaml": "^3.4|^4.0|^5.0|^6.0|^7.0"
     },
     "bin": [
         "tombstone-analyzer"

--- a/src/analyzer/composer.json
+++ b/src/analyzer/composer.json
@@ -16,7 +16,7 @@
         "nikic/php-parser": "^4.0|^5.0",
         "phpunit/php-text-template": "^1.2.1|^2.0|^3.0",
         "scheb/tombstone-core": "self.version",
-        "symfony/finder": "^4.1|^5.0|^6.0",
+        "symfony/finder": "^3.4|^4.1|^5.0|^6.0",
         "symfony/config": "^3.4|^4.0|^5.0|^6.0",
         "symfony/console": "^3.4|^4.0|^5.0|^6.0",
         "symfony/yaml": "^3.4|^4.0|^5.0|^6.0"


### PR DESCRIPTION
**Description**

I'm planning to use this project to help us remove a legacy Symfony 3.4 application. The Finder component used by the analyzer was the only Symfony component not marked as 3.4 compatible. However, it uses no 4.0+ specific features as far as I can see.

While working on it, I also took the opportunity to mark Symfony 7.0+ support for this library.