### PR TITLE
Add support for phpunit/php-text-template v4 to remove conflict with PHPUnit v11 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-json": "*",
         "ext-dom": "*",
         "nikic/php-parser": "^4.0|^5.0",
-        "phpunit/php-text-template": "^1.2.1|^2.0|^3.0",
+        "phpunit/php-text-template": "^1.2.1|^2.0|^3.0|^4.0",
         "psr/log": "^1.0|^2.0|^3.0",
         "symfony/finder": "^3.4|^4.1|^5.0|^6.0|^7.0",
         "symfony/config": "^3.4|^4.0|^5.0|^6.0|^7.0",

--- a/src/analyzer/composer.json
+++ b/src/analyzer/composer.json
@@ -14,7 +14,7 @@
         "php": ">=7.1.3",
         "ext-dom": "*",
         "nikic/php-parser": "^4.0|^5.0",
-        "phpunit/php-text-template": "^1.2.1|^2.0|^3.0",
+        "phpunit/php-text-template": "^1.2.1|^2.0|^3.0|^4.0",
         "scheb/tombstone-core": "self.version",
         "symfony/finder": "^3.4|^4.1|^5.0|^6.0|^7.0",
         "symfony/config": "^3.4|^4.0|^5.0|^6.0|^7.0",


### PR DESCRIPTION
Updated composer.json to allow installation of phpunit/php-text-template version 4.0 and above, ensuring compatibility with newer releases.

<!--
👍🎉 First off, thanks for taking the time to contribute! 🎉👍

Here are some tips for you:
 - Please follow the PR contribution guidelines: https://github.com/scheb/tombstone/blob/1.x/CONTRIBUTING.md#creating-a-pull-request
 - Don't break backwards compatibility. If you have to, let's discuss! :)
 - Always add/update tests and ensure the build passes
-->

**Description**
This tool cannot be installed when a project includes PHPUnit 11 since it requires `phpunit/php-text-template` 4.x. 
The upgrade looks safe as I have checked the changelog and the actual diff (https://github.com/sebastianbergmann/php-text-template/compare/3.0.1...4.0.1), the only relevant code change is the removal of the `Template::setFile()` method which is not used by your library.
