### PR TITLE
 Add support for phpunit/php-text-template v5 to remove conflict with PHPUnit v12.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-json": "*",
         "ext-dom": "*",
         "nikic/php-parser": "^4.0|^5.0",
-        "phpunit/php-text-template": "^1.2.1|^2.0|^3.0|^4.0",
+        "phpunit/php-text-template": "^1.2.1|^2.0|^3.0|^4.0|^5.0",
         "psr/log": "^1.0|^2.0|^3.0",
         "symfony/finder": "^3.4|^4.1|^5.0|^6.0|^7.0",
         "symfony/config": "^3.4|^4.0|^5.0|^6.0|^7.0",

--- a/src/analyzer/composer.json
+++ b/src/analyzer/composer.json
@@ -14,7 +14,7 @@
         "php": ">=7.1.3",
         "ext-dom": "*",
         "nikic/php-parser": "^4.0|^5.0",
-        "phpunit/php-text-template": "^1.2.1|^2.0|^3.0|^4.0",
+        "phpunit/php-text-template": "^1.2.1|^2.0|^3.0|^4.0|^5.0",
         "scheb/tombstone-core": "self.version",
         "symfony/finder": "^3.4|^4.1|^5.0|^6.0|^7.0",
         "symfony/config": "^3.4|^4.0|^5.0|^6.0|^7.0",


### PR DESCRIPTION
Updated composer.json to allow installation of phpunit/php-text-template version 5.0 and above, ensuring compatibility with newer releases.

**Description**
The [tombstone-analyzer](https://github.com/scheb/tombstone-analyzer) tool cannot be installed in a project that uses phpunit 12.5, since it requires `phpunit/php-text-template` ^5.0.

After checking the changelog [here](https://github.com/sebastianbergmann/php-text-template/blob/main/ChangeLog.md#500---2025-02-07) and the git diff between the 4.0.1 and 5.0.0 [here](https://github.com/sebastianbergmann/php-text-template/compare/4.0.1...5.0.0), it seems that no code changes were done, only upgrading the minimal version of phpunit, as well as removing support of php8.2 and adding support of php8.5.